### PR TITLE
Remove floating restrictions from swapping

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -20,29 +20,25 @@ const defaultOptions = {
   initialRows: 3,
 };
 
-function blocksValid(block1, block2) {
+function blocksCanSwap(block1, block2) {
   if (!block1 || !block2) {
     return false;
   }
   if (block1.flashTimer >= 0 || block2.flashTimer >= 0) {
     return false;
   }
-  if (block1.floatTimer > 0 || block2.floatTimer > 0) {
-    return false;
-  }
 
   return true;
 }
 
-function blocksCanSwap(block1, block2) {
-  return blocksValid(block1, block2);
-}
-
 function blocksMatch(block1, block2) {
-  if (!blocksValid(block1, block2)) {
+  if (!block1 || !block2) {
     return false;
   }
-  if (block1.floatTimer === 0 || block2.floatTimer === 0) {
+  if (block1.flashTimer >= 0 || block2.flashTimer >= 0) {
+    return false;
+  }
+  if (block1.floatTimer >= 0 || block2.floatTimer >= 0) {
     return false;
   }
   if (!block1.color || !block2.color) {


### PR DESCRIPTION
Allow floating blocks to be swapped.
Remove intermediary function for checking block validity as swapping and matching are now quite different.