### PR TITLE
Make engine inputs deterministic

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -186,7 +186,7 @@ function step(stateJSON, events) {
     }
   });
 
-  events.forEach((event) => {
+  events.slice().sort().forEach((event) => {
     const [, type, param] = event;
 
     if (type === 'swap') {
@@ -408,15 +408,21 @@ class GameEngine {
   }
 
   exportState() {
-    return global.btoa(JSON.stringify({
+    const dump = JSON.stringify({
       state: this.initialState,
       events: this.eventsByTime,
-    }));
+    });
+    if (global.btoa) {
+      return global.btoa(dump);
+    }
+    return dump;
   }
 
   importState(dump) {
-    const imported = JSON.parse(global.atob(dump));
-
+    if (global.atob) {
+      dump = global.atob(dump)
+    }
+    const imported = JSON.parse(dump);
     this.invalidateCache();
     this.initialState = imported.state;
     this.eventsByTime = imported.events;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,10 @@
+/**
+ * Shuffles array in place. ES6 version
+ * @param {Array} a items The array containing the items.
+ */
+module.exports.shuffle = ((a) => {
+  for (let i = a.length; i; --i) {
+    let j = Math.floor(Math.random() * i);
+    [a[i - 1], a[j]] = [a[j], a[i - 1]];
+  }
+});

--- a/test/test-engine.js
+++ b/test/test-engine.js
@@ -1,0 +1,49 @@
+const GameEngine = require('../lib/engine.js');
+const shuffle = require('../lib/util.js').shuffle;
+
+module.exports.testDeterminism = function (test) {
+  // Make two copies of the same game.
+  const firstGame = new GameEngine();
+  const secondGame = new GameEngine();
+  secondGame.importState(firstGame.exportState());
+
+  const numBlocks = firstGame.width * firstGame.height;
+
+  // Create random events.
+  const events = [];
+  for (let i = 0; i < 1000; ++i) {
+    const eventTime = parseInt(Math.random() * 50);
+    if (Math.random() < 0.9) {
+      events.push([eventTime, "swap", parseInt(Math.random() * numBlocks)]);
+    }
+    else {
+      events.push([eventTime, "addRow"]);
+    }
+  }
+
+  // Play the events on the first game.
+  events.forEach((event) => {
+    firstGame.addEvent(...event);
+  });
+  // Scramble the events and play them back on the second game.
+  shuffle(events);
+  events.forEach((event) => {
+    secondGame.addEvent(...event);
+  });
+
+  // The engine is supposed to be deterministic so the final states should agree.
+  for (let i = 0; i < 100; ++i) {
+    firstGame.step();
+    secondGame.step();
+  }
+  let firstState = firstGame.step();
+  let secondState = secondGame.step();
+
+  test.expect(1);
+  test.strictEqual(
+    JSON.stringify(firstState),
+    JSON.stringify(secondState),
+    'Indeterministic result'
+  );
+  test.done();
+};


### PR DESCRIPTION
Add a util library with a function for shuffling arrays.
Export engine state in plain JSON if global.btoa is unavailable.
Define a deterministic order for event processing to stay in sync even when receiving multiple events at the same time.
Add a test for engine determinism.

refs: #24