### PR TITLE
Add tests for basic chains

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -335,6 +335,7 @@ function step(stateJSON, events) {
 class GameEngine {
   constructor(options = {}) {
     const initialRNG = new JKISS31();
+    const colors = options.colors;
 
     this.width = (options.width || defaultOptions.width);
     this.height = (options.height || defaultOptions.height);
@@ -355,9 +356,19 @@ class GameEngine {
       blocks: Array.from({ length: this.width * this.height }, newBlock),
     };
 
-    // The first iteration only populates state.nextRow
-    for (let i = 0; i < state.initialRows + 1; ++i) {
-      addRow(state);
+    if (colors) {
+      if (colors.length !== this.width * this.height) {
+        throw new Error("Dimension mismatch");
+      }
+      colors.forEach((color, i) => {
+        state.blocks[i].color = color;
+      });
+    }
+    else {
+      // The first iteration only populates state.nextRow
+      for (let i = 0; i < state.initialRows + 1; ++i) {
+        addRow(state);
+      }
     }
 
     this.initialState = JSON.stringify(state);
@@ -388,6 +399,12 @@ class GameEngine {
     ++this.time;
 
     return JSON.parse(state);
+  }
+
+  get colors() {
+    const state = this.step();
+    --this.time;
+    return Array.from(state.blocks, (block) => block.color);
   }
 
   invalidateCache() {

--- a/test/test-engine.js
+++ b/test/test-engine.js
@@ -1,6 +1,12 @@
 const GameEngine = require('../lib/engine.js');
 const shuffle = require('../lib/util.js').shuffle;
 
+// Block colors
+const R = 'red';
+const G = 'green';
+const B = 'blue';
+const _ = null;
+
 module.exports.testDeterminism = function (test) {
   // Make two copies of the same game.
   const firstGame = new GameEngine();
@@ -47,3 +53,57 @@ module.exports.testDeterminism = function (test) {
   );
   test.done();
 };
+
+function runGame(game, numSteps) {
+  let maxChain = 0;
+  for (let i = 0; i < numSteps; ++i) {
+    maxChain = Math.max(
+      maxChain,
+      game.step().chainNumber
+    );
+  }
+  return maxChain;
+}
+
+module.exports.testHorizontalChain = function (test) {
+  const horizontalSetup = [
+    _, G, G, R, R, _,
+    G, R, R, B, B, B,
+  ];
+  const game = new GameEngine({
+    width: 6,
+    height: 2,
+    colors: horizontalSetup,
+  });
+  const maxChain = runGame(game, 100);
+
+  test.expect(2);
+  test.strictEqual(maxChain, 2);
+  test.ok(game.colors.every(color => color === null));
+  test.done();
+}
+
+module.exports.testVerticalChain = function (test) {
+  const verticalSetup = [
+    B,
+    B,
+    G,
+    G,
+    R,
+    R,
+    R,
+    G,
+    B,
+  ];
+  const game = new GameEngine({
+    width: 1,
+    height: 9,
+    colors: verticalSetup,
+  });
+  const maxChain = runGame(game, 100);
+
+  test.expect(2);
+  test.strictEqual(maxChain, 2);
+  test.ok(game.colors.every(color => color === null));
+  test.done();
+}


### PR DESCRIPTION
Add support for setting the initial colors of the blocks when constructing an engine.
Aad a method for getting the current colors of the blocks of an engine.
Add tests for horizontal and vertical chains that make sure that basic setups clear.

refs: https://github.com/frostburn/panel-league/issues/30