### PR TITLE
Implement vs. mode

### DIFF
--- a/lib/engine-basic.js
+++ b/lib/engine-basic.js
@@ -148,7 +148,12 @@ const handleEvents = ((state, events) => {
   const garbage = state.garbage;
   const blocks = state.blocks;
 
-  events.slice().sort().forEach((event) => {
+  events = events.slice().sort();
+  if (events.find((event) => event.type === 'clearAll')) {
+    blocks.forEach(clearBlock);
+    garbage.length = 0;
+  }
+  events.forEach((event) => {
     if (event.type === 'swap') {
       const index = event.index
       if (index % state.width < state.width - 1) {
@@ -173,9 +178,9 @@ const handleEvents = ((state, events) => {
       if (blocks.slice(0, state.width).every(block => !block.color)) {
         addRow(state);
         garbage.forEach(slab => ++slab.y);
-        effects.push(['addRow']);
+        effects.push({type: 'addRow'});
       } else {
-        effects.push(['gameOver']);
+        effects.push({type: 'gameOver'});
       }
     } else if (event.type === 'addGarbage') {
       const slab = Object.assign({}, event.slab);
@@ -242,7 +247,7 @@ const handleGravity = ((state) => {
       }
     } else {
       if (block.floatTimer >= 0) {
-        effects.push(["blockLanded", i]);
+        effects.push({type: "blockLanded", index: i});
       }
       block.floatTimer = -1;
     }
@@ -316,14 +321,24 @@ const handleTimers = ((state) => {
   clearMatches(blocks);
 
   if (!chainAlive) {
+    effects.push({
+      type: "chainDone",
+      chainNumber: state.chainNumber,
+    });
     state.chainNumber = 0;
   }
   if (chainMatchMade) {
-    effects.push(["chainMatchMade", state.chainNumber]);
     state.chainNumber++;
+    effects.push({
+      type: "chainMatchMade",
+      chainNumber: state.chainNumber
+    });
   }
   else if (matchMade) {
-    effects.push(["matchMade", state.chainNumber]);
+    effects.push({
+      type: "matchMade",
+      chainNumber: state.chainNumber
+    });
   }
 
   return effects;

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -102,16 +102,22 @@ class StandardStepper {
     // Handle flags and timers and check if we are still chaining matches into more matches
     effects = effects.concat(basic.handleTimers(state));
 
-    // Handle scoring and other play related accessories
-    this.handleEffects(state, effects);
-
     return effects;
   }
 
-  handleEffects(state, effects) {
-    // For subclasses.
+  // Add extra backreferences that don't need to be cached
+  postProcess(state) {
+    state.garbage.forEach((slab) => {
+      for (let y = 0; y < slab.height; ++y) {
+        for (let x = 0; x < slab.width; ++x) {
+          const block = garbage.garbageCoordsToBlock(state, slab.x + x, slab.y + y);
+          if (block) {
+            block.slab = slab;
+          }
+        }
+      }
+    });
   }
-
 }
 
 class ScoringStepper extends StandardStepper {
@@ -121,11 +127,10 @@ class ScoringStepper extends StandardStepper {
     return state;
   }
 
-  handleEffects(state, effects) {
-    super.handleEffects(state, effects);
+  step(state, events) {
+    const effects = super.step(state, events);
     effects.forEach((effect) =>{
-      const [type, param] = effect;
-      switch (type) {
+      switch (effect.type) {
         case 'gameOver':
           state.score = 0;
           break;
@@ -133,15 +138,113 @@ class ScoringStepper extends StandardStepper {
           state.score += 1;
           break;
         case 'chainMatchMade':
-          state.score += 10 * (param + 1);
+          state.score += 10 * effect.chainNumber;
           break;
         case 'matchMade':
-          state.score += 9 * (param + 1);
+          state.score += 9 * effect.chainNumber;
           break;
       }
     });
+    return effects;
   }
 }
+
+class VsStepper extends StandardStepper {
+  initializeState(options) {
+    const numPlayers = defaultTo(options.numPlayers, 2);
+    const parentState = {
+      time: 0,
+      numPlayers: numPlayers,
+      childStates: [],
+      nextEvents: {},
+    }
+    for (let player = 0; player < numPlayers; ++player) {
+      const childState = super.initializeState(options);
+      childState.player = player;
+      childState.score = 0;
+      parentState.childStates.push(childState);
+      parentState.nextEvents[player] = [];
+    }
+    return parentState;
+  }
+
+  step(parentState, events) {
+    const numPlayers = parentState.numPlayers;
+    ++parentState.time;
+    events.forEach((event) => {
+      parentState.nextEvents[event.player].push(event);
+    });
+    const effectsByChild = {};
+    for (let player = 0; player < numPlayers; ++player) {
+      const childState = parentState.childStates[player];
+      const childEvents = parentState.nextEvents[player];
+      const childEffects = super.step(childState, childEvents);
+      effectsByChild[player] = childEffects;
+      parentState.nextEvents[player] = [];
+    }
+    for (let player = 0; player < numPlayers; ++player) {
+      effectsByChild[player].forEach((effect) => {
+        this.pushOwnEvent(parentState, effect, player);
+      });
+      for (let other = 0; other < numPlayers; ++other) {
+        if (other == player) {
+          continue;
+        }
+        effectsByChild[player].forEach((effect) => {
+          this.pushOpponentEvent(
+            parentState,
+            effect,
+            player,
+            other
+          );
+        });
+      }
+    }
+    return [];
+  }
+
+  pushOwnEvent(parentState, effect, player) {
+    const nextEvents = parentState.nextEvents[player];
+    const childState = parentState.childStates[player];
+    if (effect.type == 'gameOver') {
+      --childState.score;
+      nextEvents.push({
+        receiver: player,
+        type: 'clearAll',
+      });
+      for (let i = 0; i < childState.initialRows; ++i) {
+        nextEvents.push({
+          receiver: player,
+          type: 'addRow',
+        });
+      }
+    }
+  }
+
+  pushOpponentEvent(parentState, effect, sender, receiver) {
+    const nextEvents = parentState.nextEvents[receiver];
+    if (effect.type == 'chainDone' && effect.chainNumber) {
+      nextEvents.push({
+        sender,
+        receiver,
+        type: 'addGarbage',
+        slab: {
+          x: 0,
+          width: parentState.childStates[receiver].width,
+          height: effect.chainNumber,
+        }
+      });
+    }
+  }
+
+  postProcess(parentState) {
+    parentState.childStates.forEach((childState) => {
+      super.postProcess(childState);
+    });
+  }
+}
+
+const steppers = [StandardStepper, ScoringStepper, VsStepper];
 
 class GameEngine {
   constructor(options = {}) {
@@ -190,17 +293,7 @@ class GameEngine {
     this.statesByTime.delete(this.lastValidTime - STATE_CACHE_SIZE);
     ++this.time;
 
-    // Add garbage slab backreferences for the UI.
-    state.garbage.forEach((slab) => {
-      for (let y = 0; y < slab.height; ++y) {
-        for (let x = 0; x < slab.width; ++x) {
-          const block = garbage.garbageCoordsToBlock(state, slab.x + x, slab.y + y);
-          if (block) {
-            block.slab = slab;
-          }
-        }
-      }
-    });
+    this.stepper.postProcess(state);
     return state;
   }
 
@@ -265,9 +358,33 @@ class GameEngine {
     this.statesByTime.set(data.time, data.state);
   }
 
+  serialize() {
+    const attrs = Object.assign({}, this);
+    delete attrs.statesByTime;
+    delete attrs.stepper;
+    delete attrs.effects;
+    delete attrs.listeners;
+    const data = {
+      attrs,
+      stepper: steppers.indexOf(this.stepper.constructor),
+      cache: this.exportCache(),
+    };
+    return JSON.stringify(data);
+  }
+
+  static unserialize(data) {
+    const game = new this();
+    data = JSON.parse(data);
+    Object.assign(game, data.attrs);
+    game.stepper = new steppers[data.stepper]();
+    game.importCache(data.cache);
+    return game;
+  }
+
   emitEffects(time, effects) {
     effects.forEach((effect) => {
-      const effectJSON = JSON.stringify([time, ...effect]);
+      effect.time = time;
+      const effectJSON = JSON.stringify(effect);
       if (!this.effects.has(effectJSON)) {
         this.effects.add(effectJSON);
         this.emitEffect(effect);
@@ -276,19 +393,15 @@ class GameEngine {
   }
 
   on(type, callback) {
-    this.listeners.push([type, callback]);
+    this.listeners.push({type, callback});
   }
 
-  // TODO: Emit time and other params.
   emitEffect(effect) {
-    const [type] = effect;
-    this.listeners.forEach((listener) => {
-      const [listenedType, callback] = listener;
-      if (type === listenedType) {
-        callback();
-      }
-    });
+    const listener = this.listeners.find((listener) => listener.type === effect.type);
+    if (listener) {
+      listener.callback();
+    }
   }
 }
 
-module.exports = {StandardStepper, ScoringStepper, GameEngine};
+module.exports = {StandardStepper, ScoringStepper, VsStepper, GameEngine};

--- a/ui/debug/dist/index_vs.html
+++ b/ui/debug/dist/index_vs.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Panel League vs. Battle</title>
+</head>
+<body>
+  <h2>Panel League vs. Battle</h2>
+  <div id="player-container" style="width: 50%; float: left;"></div>
+  <div id="opponent-container" style="width: 50%; float: left;"></div>
+  <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="./asset/js/index_vs.js"></script>
+</body>
+</html>

--- a/ui/debug/package.json
+++ b/ui/debug/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "./node_modules/.bin/webpack",
-    "watch": "./node_modules/.bin/webpack -d --watch"
+    "watch": "./node_modules/.bin/webpack -d --watch",
+    "vs": "node server_vs.js"
   },
   "dependencies": {
     "express": "^4.10.2",

--- a/ui/debug/server_vs.js
+++ b/ui/debug/server_vs.js
@@ -1,0 +1,77 @@
+const app = require('express')();
+const http = require('http').Server(app);
+const io = require('socket.io')(http);
+const {GameEngine, VsStepper} = require('../../lib/engine');
+
+app.get('/', (req, res) => {
+  res.sendFile(`${__dirname}/dist/index_vs.html`);
+});
+
+app.get('/asset/js/index_vs.js', (req, res) => {
+  res.sendFile(`${__dirname}/dist/asset/js/index_vs.js`);
+});
+
+io.on('connection', (socket) => {
+  console.log('New client connected');
+
+  if (!pendingPlayer) {
+    pendingPlayer = socket;
+  }
+  else {
+    console.log('New game starting');
+    const game = new GameEngine({
+      stepper: VsStepper,
+      flashTime: 40,
+      floatTime: 10,
+      swapTime: 3,
+      garbageFlashTime: 2,
+      blockTypes: ['red', 'gold', 'lawngreen', 'darkcyan', 'blue', 'blueviolet'],
+    });
+    games.push(game);
+    pendingPlayer.game = game;
+    socket.game = game;
+    pendingPlayer.opponent = socket;
+    socket.opponent = pendingPlayer;
+    const data = {
+      player: 0,
+      game: game.serialize(),
+      frameRate: frameRate,
+      cache: game.exportCache(),
+    }
+    pendingPlayer.emit('connected', data);
+    data.player = 1;
+    socket.emit('connected', data);
+    game.players = [pendingPlayer, socket];
+    pendingPlayer = null;
+  }
+  socket.on('game event', (data) => {
+    socket.game.addEvent(data.event);
+    socket.opponent.emit('game event', data);
+  });
+  socket.on('disconnect', () => {
+    console.log('Client disconnected');
+  });
+});
+
+const games = [];
+let pendingPlayer = null;
+
+function step() {
+  games.forEach((game) => {
+    game.step();
+    if (game.time % 10 === 0) {
+      game.players.forEach((player) => {
+        player.emit('clock', {
+          time: game.time
+        });
+      });
+    }
+  });
+}
+
+const frameRate = 30;
+const mainLoop = setInterval(step, 1000 / frameRate);
+
+http.listen(3000, () => {
+    console.log('Listening on port 3000');
+});

--- a/ui/debug/src/js/grid.js
+++ b/ui/debug/src/js/grid.js
@@ -12,7 +12,7 @@ const $newBlock = (() => {
 });
 
 class Grid {
-  constructor(game, $container) {
+  constructor(game, $container, player) {
     this.game = game;
     this.width = game.width;
     this.height = game.height;
@@ -44,26 +44,29 @@ class Grid {
       $previewRow.append($block);
       this.$previewBlocks.push($block);
     }
-
-    this.$blocks.forEach(($block, index) => {
-      $block.click((ev) => {
-        ev.preventDefault();
-        this.game.addEvent({
-          time: this.game.time,
-          type: 'swap',
-          index
+    if (player !== null) {
+      this.$blocks.forEach(($block, index) => {
+        $block.click((ev) => {
+          ev.preventDefault();
+          this.game.addEvent({
+            player: player,
+            time: this.game.time,
+            type: 'swap',
+            index
+          });
         });
       });
-    });
-    this.$previewBlocks.forEach(($block) => {
-      $block.click((ev) => {
-        ev.preventDefault();
-        this.game.addEvent({
-          time: this.game.time,
-          type: 'addRow'
+      this.$previewBlocks.forEach(($block) => {
+        $block.click((ev) => {
+          ev.preventDefault();
+          this.game.addEvent({
+            player: player,
+            time: this.game.time,
+            type: 'addRow'
+          });
         });
       });
-    });
+    }
     $container.append(this.$chainNumber, this.$time, this.$score);
   }
 

--- a/ui/debug/src/js/index.js
+++ b/ui/debug/src/js/index.js
@@ -37,8 +37,6 @@ $(() => {
       }, 1000 / frameRate);
     });
 
-    // We expect the browser clock to run slower than
-    // the server clock so we only implement catch up.
     socket.on('clock', (data) => {
       const serverTime = data.time;
       while (currentGame.time < serverTime) {

--- a/ui/debug/src/js/index_vs.js
+++ b/ui/debug/src/js/index_vs.js
@@ -1,0 +1,154 @@
+/* eslint-env browser, jquery */
+
+const {GameEngine, VsStepper} = require('../../../../lib/engine');
+const Grid = require('./grid');
+let EngineClass = GameEngine;
+let currentGame;
+let step;
+
+$(() => {
+  if ('io' in window) {
+    $('#player-container').text('Waiting for an opponent to join...');
+    let waitTime = 0;
+    const socket = io();
+    EngineClass = class extends GameEngine {
+      addEvent(event) {
+        super.addEvent(event);
+        socket.emit('game event', {'event': event});
+      }
+      addBroadcastEvent(event) {
+        super.addEvent(event);
+      }
+    };
+
+    socket.on('connected', (data) => {
+      $('#player-container').empty();
+      player = data.player;
+      opponent = 1 - player;
+      currentGame = EngineClass.unserialize(data.game);
+      init(player, opponent);
+      frameRate = data.frameRate;
+      mainLoop = window.setInterval(() => {
+        if (waitTime-- <= 0) {
+          step();
+        }
+      }, 1000 / frameRate);
+    });
+
+    socket.on('clock', (data) => {
+      const serverTime = data.time;
+      while (currentGame.time < serverTime) {
+        step();
+      }
+      waitTime = currentGame.time - serverTime;
+    });
+
+    socket.on('game event', (data) => {
+      currentGame.addBroadcastEvent(data.event);
+    });
+  }
+
+  function init(player, opponent) {
+    const $playerContainer = $('#player-container');
+    const $opponentContainer = $('#opponent-container');
+    if (typeof currentGame === 'undefined') {
+      currentGame = new EngineClass({
+        stepper: VsStepper,
+        flashTime: 40,
+        floatTime: 10,
+        swapTime: 3,
+        garbageFlashTime: 2,
+        blockTypes: ['red', 'gold', 'lawngreen', 'darkcyan', 'blue', 'blueviolet'],
+      });
+    }
+    const playerGrid = new Grid(currentGame, $playerContainer, player);
+    const opponentGrid = new Grid(currentGame, $opponentContainer, ('io' in window) ? null : opponent);
+
+    let swapperX = 0;
+    let swapperY = 0;
+
+    let mainLoop;
+
+    // Keyboard input
+    $(window).keydown((e) => {
+      displaySwapper('none');
+      switch (e.key) {
+        case 'ArrowUp':
+          if (swapperY > 0) {
+            --swapperY;
+          }
+          break;
+
+        case 'ArrowDown':
+          if (swapperY < currentGame.height - 1) {
+            ++swapperY;
+          }
+          break;
+
+        case 'ArrowLeft':
+          if (swapperX > 0) {
+            --swapperX;
+          }
+          break;
+
+        case 'ArrowRight':
+          if (swapperX < currentGame.width - 2) {
+            ++swapperX;
+          }
+          break;
+
+        // The f key was chosen as it is in a natural position for the left hand.
+        case 'f':
+          currentGame.addEvent({
+            player: player,
+            time: currentGame.time,
+            type: 'swap',
+            index: swapperX + (currentGame.width * swapperY)
+          });
+          break;
+
+        case ' ':
+          currentGame.addEvent({
+            player: player,
+            time: currentGame.time,
+            type: 'addRow'
+          });
+          break;
+
+        default:
+          break;
+      }
+      displaySwapper('solid');
+    });
+
+    function displaySwapper(borderStyle) {
+      const index = swapperX + (currentGame.width * swapperY);
+      playerGrid.$blocks[index].css({
+        'border-style': borderStyle,
+        'box-sizing': 'border-box',
+      });
+      playerGrid.$blocks[index + 1].css({
+        'border-style': borderStyle,
+        'box-sizing': 'border-box',
+      });
+    }
+    displaySwapper('solid');
+
+    function update(state) {
+      playerGrid.update(state.childStates[player]);
+      opponentGrid.update(state.childStates[opponent]);
+    }
+
+    step = (() => {
+      const state = currentGame.step();
+      update(state);
+    });
+    if (!('io' in window)) {
+      mainLoop = window.setInterval(step, 1000 / 30);
+    }
+  }
+
+  if (!('io' in window)) {
+    init(0, 1);
+  }
+});

--- a/ui/debug/webpack.config.js
+++ b/ui/debug/webpack.config.js
@@ -1,12 +1,13 @@
 const webpack = require('webpack');
 
 module.exports = {
-  entry: [
-    './src/js/index.js',
-  ],
+  entry: {
+    index: './src/js/index.js',
+    index_vs: './src/js/index_vs.js'
+  },
   output: {
-    filename: './dist/asset/js/index.js',
-    sourceMapFilename: './dist/asset/js/index.js.map',
+    filename: './dist/asset/js/[name].js',
+    sourceMapFilename: './dist/asset/js/[name].js.map',
   },
   plugins: [new webpack.optimize.UglifyJsPlugin()],
 };


### PR DESCRIPTION
Emit play effects as objects for extensibility.
Move state specific post-processing to the stepper.
Add a vs. mode stepper driving multiple child states and handling garbage sending.
Implement a clear all event for reseting the grid after game over.
Implement engine serialization.
Implement a frontend and backend server for vs. mode.

refs: https://github.com/frostburn/panel-league/issues/35