### PR TITLE
Fix support with fall

### DIFF
--- a/lib/engine-basic.js
+++ b/lib/engine-basic.js
@@ -24,14 +24,11 @@ const blocksCanSwap = ((block1, block2, above1, above2) => {
   return true;
 });
 
-const blocksMatch = ((block1, block2) => {
+const blocksMatch = ((block1, block2, bellow1, bellow2) => {
   if (!block1 || !block2) {
     return false;
   }
   if (block1.flashTimer >= 0 || block2.flashTimer >= 0) {
-    return false;
-  }
-  if (block1.floatTimer >= 0 || block2.floatTimer >= 0) {
     return false;
   }
   if (!block1.color || !block2.color) {
@@ -41,6 +38,16 @@ const blocksMatch = ((block1, block2) => {
     return false;
   }
   if (block1.garbage || block2.garbage) {
+    return false;
+  }
+  // Blocks above swapping air are in a limbo.
+  // They are floating/falling in terms of gravity, but
+  // are still "supported" by the solid block sliding away underneath.
+  const block1_floating = block1.floatTimer >= 0;
+  const block2_floating = block2.floatTimer >= 0;
+  const bellow1_supporting = bellow1 && bellow1.swapTimer && !bellow1.color;
+  const bellow2_supporting = bellow2 && bellow2.swapTimer && !bellow2.color;
+  if ((block1_floating && !bellow1_supporting) || (block2_floating && !bellow2_supporting)){
     return false;
   }
   if (block1.color === block2.color) {
@@ -65,17 +72,21 @@ const findMatches = ((state, blocks) => {
   blocks.forEach((block, i) => {
     const bellow = blocks[i + state.width];
     const above = blocks[i - state.width];
-    let left;
-    let right;
+    let left, right, left_bellow, right_bellow;
 
     if (i % state.width > 0) {
       left = blocks[i - 1];
+      left_bellow = blocks[i - 1 + state.width];
     }
     if (i % state.width < state.width - 1) {
       right = blocks[i + 1];
+      right_bellow = blocks[i + 1 + state.widht];
     }
 
-    if (blocksMatch(left, block) && blocksMatch(block, right)) {
+    if (
+      blocksMatch(left, block, left_bellow, bellow) &&
+      blocksMatch(block, right, bellow, right_bellow)
+    ) {
       left.matching = true;
       block.matching = true;
       right.matching = true;
@@ -259,7 +270,7 @@ const handleGravity = ((state) => {
     // A block can float or fall if
     // it is not at ground level and
     // it is not flashing
-    // and the block (or air) bellow is not swapping and
+    // and the (solid) block bellow is not swapping and
     // either beneath there's air or a floating/falling block.
 
     // Swapping blocks start floating, but wait until
@@ -271,7 +282,7 @@ const handleGravity = ((state) => {
     if (
       bellow &&
       (block.flashTimer < 0) &&
-      !bellow.swapTimer &&
+      (!bellow.color || !bellow.swapTimer) &&
       (!bellow.color || bellow.floatTimer >= 0)
     ) {
       if (block.floatTimer < 0) {

--- a/test/test-engine.js
+++ b/test/test-engine.js
@@ -423,3 +423,31 @@ module.exports.testCatch = function (test) {
   test.ok(game.colors.every(color => color === null));
   test.done();
 }
+
+module.exports.testSupportWithFall = function (test) {
+  const setup = [
+    _, G, _,
+    G, R, _,
+    B, R, G,
+    R, R, B,
+  ];
+  const options = Object.assign(
+    {width: 3, height: 4, colors: setup},
+    dynamicOptions
+  );
+
+  const timeRange = 5;
+  test.expect(2 * timeRange);
+  for (let time = 4; time < 4 + timeRange; ++time) {
+    const game = new GameEngine(options);
+    game.addEvent({
+      time,
+      type: "swap",
+      index: 6
+    });
+    const maxChain = runGame(game, 20);
+    test.strictEqual(maxChain, 1);
+    test.ok(game.colors.every(block => block !== G));
+  }
+  test.done();
+}


### PR DESCRIPTION
Change the gravity rules so that blocks under which a supporting piece is swapped from can participate in chains.
Change matching rules to compensate for the new gravity rules so that late slip technique is still valid.