### PR TITLE
Prevent "chain bleeding"

### DIFF
--- a/lib/panel-league/basic.js
+++ b/lib/panel-league/basic.js
@@ -327,7 +327,7 @@ const handleChaining = ((state) => {
     if (block.chaining || !block.matching) {
       return false;
     }
-    if (neighbour.chaining) {
+    if (neighbour.chaining && neighbour.matching) {
       block.chaining = true;
       return true;
     };

--- a/test/test-engine.js
+++ b/test/test-engine.js
@@ -451,3 +451,30 @@ module.exports.testSupportWithFall = function (test) {
   }
   test.done();
 }
+
+module.exports.testNoChainBleed = function (test) {
+  const setup = [
+    G, _, _,
+    R, B, _,
+    R, R, B,
+    R, B, R,
+  ];
+  const options = Object.assign(
+    {width: 3, height: 4, colors: setup},
+    dynamicOptions
+  );
+
+  const timeRange = 10;
+  test.expect(timeRange);
+  for (let time = 0; time < timeRange; ++time) {
+    const game = new GameEngine(options);
+    game.addEvent({
+      time,
+      type: "swap",
+      index: 7
+    });
+    const maxChain = runGame(game, 20);
+    test.strictEqual(maxChain, 0);
+  }
+  test.done();
+}


### PR DESCRIPTION
Prevent chaining flags bleeding from falling blocks into unrelated matching blocks.