### PR TITLE
Hide engine caching details

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -1,31 +1,33 @@
 const panelLeague = require('./panel-league/stepper.js');
 const defaultTo = require('lodash/defaultTo');
 
-const STATE_CACHE_SIZE = 16;
+const STATE_CACHE_SIZE = 128;
 
 const defaultOptions = {
   width: 6,
   height: 8,
   stepper: "panelLeagueStandard",
+  stateCacheSize: STATE_CACHE_SIZE,
 };
 
 class GameEngine {
   constructor(options = {}) {
     const stepper = defaultTo(options.stepper, defaultOptions.stepper);
     this.stepper = panelLeague.factory(stepper);
+    this.stateCacheSize = defaultTo(options.stateCacheSize, defaultOptions.stateCacheSize);
     // Width and height are technically game specific but we cache them for convenience.
     const width = defaultTo(options.width, defaultOptions.width);
     const height = defaultTo(options.height, defaultOptions.height);
     const colors = options.colors;
     const state = this.stepper.initializeState(options);
 
-    this.time = state.time;
+    this._time = state.time;
     this.eventsByTime = {};
     this.initialState = JSON.stringify(state);
 
     // Smart state cache for handling input lag.
     this.statesByTime = new Map();
-    this.lastValidTime = this.time;
+    this.lastValidTime = null;
 
     // Effect set for emmitting unique events to listeners.
     this.effects = new Set();
@@ -38,44 +40,69 @@ class GameEngine {
   step() {
     let state;
 
-    if (!this.lastValidTime) {
-      state = this.initialState;
+    if (this.lastValidTime === null) {
+      const stateJSON = this.initialState;
+
+      state = JSON.parse(stateJSON);
+      this.statesByTime.set(state.time, stateJSON);
+      this.lastValidTime = state.time;
     } else {
-      state = this.statesByTime.get(this.lastValidTime);
+      const stateJSON = this.statesByTime.get(this.lastValidTime);
+
+      if (!stateJSON) {
+        throw new Error('Unexpected cache miss');
+      }
+      state = JSON.parse(stateJSON);
     }
     if (!state) {
       throw new Error('State cache corrupted');
     }
-    state = JSON.parse(state);
-    for (let instant = this.lastValidTime; instant < this.time; ++instant) {
+    for (let instant = this.lastValidTime; instant < this._time; ++instant) {
       const events = this.eventsByTime[instant] || [];
       const effects = this.stepper.step(state, events);
       this.emitEffects(instant, effects);
       this.statesByTime.set(instant + 1, JSON.stringify(state));
     }
-    this.lastValidTime = this.time;
-    this.statesByTime.delete(this.lastValidTime - STATE_CACHE_SIZE);
-    ++this.time;
+    this.lastValidTime = this._time;
+    this.statesByTime.delete(this.lastValidTime - this.stateCacheSize);
+    ++this._time;
 
     this.stepper.postProcess(state);
     return state;
   }
 
   invalidateCache() {
-    this.lastValidTime = 0;
+    this.lastValidTime = null;
     this.statesByTime = new Map();
+  }
+
+  get time() {
+    return this._time;
+  }
+
+  set time(value) {
+    const state = this.statesByTime.get(value);
+
+    if (!state) {
+      this.invalidateCache();
+    } else {
+      this.lastValidTime = value;
+    }
+    this._time = value;
   }
 
   addEvent(event) {
     const events = this.eventsByTime[event.time] || [];
 
-    if (event.time <= this.lastValidTime - STATE_CACHE_SIZE) {
-      this.invalidateCache();
-    } else {
-      this.lastValidTime = Math.min(this.lastValidTime, event.time);
-    }
     events.push(event);
     this.eventsByTime[event.time] = events;
+    if (this.lastValidTime === null) {
+      return;
+    }
+    this.lastValidTime = Math.min(this.lastValidTime, event.time);
+    if (!this.statesByTime.has(this.lastValidTime)) {
+      this.invalidateCache();
+    }
   }
 
   exportState() {

--- a/ui/debug/src/js/index.js
+++ b/ui/debug/src/js/index.js
@@ -178,12 +178,10 @@ $(() => {
   }
 
   $('#btn-reset').click(() => {
-    currentGame.invalidateCache();
     currentGame.time = 0;;
   });
   $('#btn-step').click(step);
   $('#btn-back').click(() => {
-    currentGame.invalidateCache();
     currentGame.time -= 2;
     debugState = currentGame.step()
     update(debugState);


### PR DESCRIPTION
Automatically invalidate engine cache if time is set out of range.
Allow other initial state times besides zero.

refs https://github.com/frostburn/panel-league/issues/37