### PR TITLE
Add development / debug mode to server script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "svg.js": "^2.4.0",
     "uglify-js": "https://github.com/mishoo/UglifyJS2.git#harmony",
     "uuid": "^3.0.1",
-    "webpack": "^2.2.0-rc.3"
+    "webpack": "^2.2.0-rc.3",
+    "webpack-dev-middleware": "^1.10.1",
+    "webpack-hot-middleware": "^2.17.1"
   }
 }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,34 @@
+const webpack = require('webpack');
+
+module.exports = {
+  entry: [
+    'webpack/hot/dev-server',
+    'webpack-hot-middleware/client',
+    './lib/ui/index.js',
+  ],
+  output: {
+    path: '/',
+    publicPath: '/asset/js/',
+    filename: 'index.js',
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015'],
+        },
+      },
+      {
+        test: /\.less$/,
+        loader: 'style-loader!css-loader!less-loader',
+      },
+    ],
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
+  ],
+};


### PR DESCRIPTION
This adds new development / debug mode to server script which compiles assets in-memory with `webpack-dev-middleware` and also implements hot reloading with `webpack-hot-middleware`. With this, webpack does not need to be run in the background in watch mode, using only `node server.js -d` is enough.