### PR TITLE
Optimize panel league stepper

### DIFF
--- a/lib/panel-league/basic.js
+++ b/lib/panel-league/basic.js
@@ -73,11 +73,17 @@ const handleSwapping = ((state) => {
     } else if (block.swapTimer < 0) {
       ++block.swapTimer;
     }
+    else {
+      state.dirty = true;
+    }
   });
 });
 
 // Match three or more similar blocks horizontally or vertically
 const findMatches = ((state, blocks) => {
+  if (!state.dirty) {
+    return false;
+  }
   let matchFound = false;
   blocks.forEach((block, i) => {
     const bellow = blocks[i + state.width];
@@ -139,6 +145,7 @@ const pushRow = ((blocks, nextRow, width) => {
 
 // When adding rows we must not create new matches unless forced to.
 const addRow = ((state) => {
+  state.dirty = true;
   if (state.nextRow) {
     pushRow(state.blocks, state.nextRow, state.width);
     // Find matches that are forced and exclude them.
@@ -172,6 +179,8 @@ const addRow = ((state) => {
 const refillBlocks = ((state) => {
   const blocks = state.blocks;
   const blockTypes = state.blockTypes;
+
+  state.dirty = true;
   state.garbage.length = 0;
   blocks.forEach(clearBlock);
   blocks.forEach((block, index) => {
@@ -319,10 +328,16 @@ const handleGravity = ((state) => {
       block.floatTimer = -1;
     }
   }
+  if (effects.length) {
+    state.dirty = true;
+  }
   return effects;
 });
 
 const handleChaining = ((state) => {
+  if (!state.dirty) {
+    return;
+  }
   floodFill(state, (block, neighbour) => {
     if (block.chaining || !block.matching) {
       return false;

--- a/lib/panel-league/basic.js
+++ b/lib/panel-league/basic.js
@@ -1,5 +1,5 @@
 const JKISS31 = require('../jkiss');
-const {newBlock, clearBlock, floodFill, shuffleInPlace} = require('./util');
+const {newBlock, clearBlock, shuffleInPlace, matrixFloodFill} = require('./util');
 
 // Block properties
 // Non-solid: Null color blocks act as air.
@@ -338,15 +338,33 @@ const handleChaining = ((state) => {
   if (!state.dirty) {
     return;
   }
-  floodFill(state, (block, neighbour) => {
-    if (block.chaining || !block.matching) {
-      return false;
+  // Flood-fills are expensive so we convert into
+  // matrix form and back to make it faster.
+  const source = [];
+  const target = [];
+
+  for (let i = 0; i < state.height; ++i) {
+    const sourceRow = [];
+    const targetRow = [];
+    for (let j = 0; j < state.width; ++j) {
+      const block = state.blocks[j + i * state.width];
+
+      sourceRow.push(block.chaining && block.matching);
+      targetRow.push(block.matching)
     }
-    if (neighbour.chaining && neighbour.matching) {
-      block.chaining = true;
-      return true;
-    };
-  });
+    source.push(sourceRow);
+    target.push(targetRow);
+  }
+  matrixFloodFill(source, target);
+  for (let i = 0; i < state.height; ++i) {
+    for (let j = 0; j < state.width; ++j) {
+      if (source[i][j]) {
+        const block = state.blocks[j + i * state.width];
+
+        block.chaining = true;
+      }
+    }
+  }
 });
 
 const handleTimers = ((state) => {

--- a/lib/panel-league/garbage.js
+++ b/lib/panel-league/garbage.js
@@ -128,6 +128,7 @@ const releaseGarbage = ((state) => {
     if (slab.flashTimer-- !== 0) {
       return;
     }
+    state.dirty = true;
     for (let x = 0; x < slab.width; ++x) {
       const block = garbageCoordsToBlock(state, slab.x + x, slab.y);
       if (block) {

--- a/lib/panel-league/stepper.js
+++ b/lib/panel-league/stepper.js
@@ -74,7 +74,7 @@ class StandardStepper {
 
     ++state.time;
 
-    state.dirty = false;
+    state.dirty = this.test;
 
     // Swap timers need to be handled before setting new swap times through events.
     basic.handleSwapping(state);

--- a/lib/panel-league/stepper.js
+++ b/lib/panel-league/stepper.js
@@ -48,6 +48,7 @@ class StandardStepper {
       blockTypes: defaultTo(options.blockTypes, defaultOptions.blockTypes),
       addRowWhileActive: defaultTo(options.addRowWhileActive, defaultOptions.addRowWhileActive),
       garbage: [],
+      dirty: true,
     };
 
     if (colors) {
@@ -72,6 +73,8 @@ class StandardStepper {
     let effects = [];
 
     ++state.time;
+
+    state.dirty = false;
 
     // Swap timers need to be handled before setting new swap times through events.
     basic.handleSwapping(state);

--- a/lib/panel-league/util.js
+++ b/lib/panel-league/util.js
@@ -92,6 +92,34 @@ module.exports.floodFill = ((state, callback) => {
   }
 });
 
+function seedFill(source, target, x, y) {
+  const row = source[y];
+
+  if (row && row[x] === false && target[y][x]) {
+    source[y][x] = true;
+    seedFill(source, target, x - 1, y);
+    seedFill(source, target, x + 1, y);
+    seedFill(source, target, x, y - 1);
+    seedFill(source, target, x, y + 1);
+  }
+}
+
+// Expand source boolean matrix into target matrix
+module.exports.matrixFloodFill = ((source, target) => {
+  for (let i = 0; i < source.length; ++i) {
+    const row = source[i];
+
+    for (let j = 0; j < row.length; ++j) {
+      if (row[j]) {
+        seedFill(source, target, j - 1, i);
+        seedFill(source, target, j + 1, i);
+        seedFill(source, target, j, i - 1);
+        seedFill(source, target, j, i + 1);
+      }
+    }
+  }
+});
+
 module.exports.shuffleInPlace = ((array, random) => {
   for (let i = array.length - 1; i > 0; --i) {
     const j = Math.floor(random() * (i + 1));

--- a/test/test-engine.js
+++ b/test/test-engine.js
@@ -22,6 +22,7 @@ module.exports.testDeterminism = function (test) {
   const events = [];
 
   secondGame.importState(firstGame.exportState());
+  secondGame.stepper.test = true;
   thirdGame.stateCacheSize = 3;
 
 


### PR DESCRIPTION
Only perform computationally intensive operations when the state changes sufficiently.
Implement simple recursive matrix flood fill and use it to make chaining flag propagation less computationally expensive.