### PR TITLE
Determine Puyo turn based rules

### DIFF
--- a/lib/common/engine.js
+++ b/lib/common/engine.js
@@ -246,6 +246,11 @@ class GameEngine {
       listener.callback(effect);
     });
   }
+
+  // The steppers are not tied to engine time so they need to be called through this.
+  callStepper(method, args) {
+    return this.stepper[method](this.currentState, this.eventsByTime[this.time] || [], args);
+  }
 }
 
 class NetworkGameEngine extends GameEngine {

--- a/lib/common/puyo/stepper.js
+++ b/lib/common/puyo/stepper.js
@@ -84,6 +84,22 @@ class BasicStepper {
   }
 
   postProcess() {}
+
+  canStep(state, events) {
+    if (state.chainNumber) {
+      if (events.length) {
+        throw new Error('Illegal moves detected');
+      }
+      return true;
+    } else if (events.length) {
+      return true;
+    }
+    return false;
+  }
+
+  canPlay(state, events) {
+    return (!events.length && !state.chainNumber);
+  }
 }
 
 class EndlessStepper extends BasicStepper {
@@ -156,6 +172,7 @@ class DuelStepper extends BasicStepper {
       childStates: [],
     };
 
+    initialRNG.scramble();
     parentState.deals = Array.from(
       { length: numDeals },
       () => basic.randomDeal(initialRNG, numColors)
@@ -170,20 +187,27 @@ class DuelStepper extends BasicStepper {
     return parentState;
   }
 
-  step(state, events) {
-    const effects = [];
+  distributeEvents(state, events) {
     const eventsForPlayer = {};
-    const hasStepped = {};
-    const nuisanceReceivers = [];
 
-    let gameOver = false;
-    ++state.time;
     for (let i = 0; i < state.numPlayers; ++i) {
       eventsForPlayer[i] = [];
     }
     events.forEach((event) => {
       eventsForPlayer[event.player].push(event);
     });
+    return eventsForPlayer;
+  }
+
+  step(state, events) {
+    const effects = [];
+    const hasStepped = {};
+    const nuisanceReceivers = [];
+    const eventsForPlayer = this.distributeEvents(state, events);
+
+    let gameOver = false;
+    ++state.time;
+
     for (let i = 0; i < state.numPlayers; ++i) {
       const childState = state.childStates[i];
 
@@ -247,10 +271,29 @@ class DuelStepper extends BasicStepper {
     if (gameOver) {
       state.childStates.forEach((childState) => {
         childState.blocks.fill(basic.emptyPuyo);
+        childState.pendingNuisance = 0;
+        childState.leftoverScore = 0;
+        childState.nuisanceX = 0;
+        childState.chainNumber = 0;
+        childState.chainScore = 0;
+        childState.allClearBonus = 0;
       });
     }
 
     return effects;
+  }
+
+  canStep(state, events) {
+    const eventsForPlayer = this.distributeEvents(state, events);
+
+    return state.childStates.every(child => super.canStep(child, eventsForPlayer[child.player]));
+  }
+
+  canPlay(state, events, args) {
+    const { player } = args;
+    const eventsForPlayer = this.distributeEvents(state, events);
+
+    return super.canPlay(state.childStates[player], eventsForPlayer[player]);
   }
 }
 


### PR DESCRIPTION
Make it possible to call stepper methods from the UI through the engine.
Add Puyo stepper methods to determine turn based rules for the game.
Fix issues with RNG scrambling.
Fix issues with game overs.