### PR TITLE
Introduce simple lobby to the user interface

### DIFF
--- a/asset/css/lobby.less
+++ b/asset/css/lobby.less
@@ -1,0 +1,12 @@
+@import './variables';
+
+.lobby {
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 2em;
+  width: 50%;
+
+  table {
+    margin-top: 2em;
+  }
+}

--- a/asset/css/style.less
+++ b/asset/css/style.less
@@ -10,4 +10,40 @@ body {
   background: @color-background;
 }
 
+table {
+  border-collapse: collapse;
+  width: 100%;
+
+  tr {
+    border-bottom: 1px solid darken(@color-background, 15%);
+    font-size: 1.1em;
+
+    th {
+      text-align: left;
+    }
+
+    td, th {
+      padding: 0.25em 0.5em;
+    }
+
+    &.selected {
+      background: lighten(@color-background, 15%);
+    }
+  }
+}
+
+button {
+  background: lighten(@color-background, 15%);
+  border: 1px solid darken(@color-background, 5%);
+  border-radius: 10%;
+  color: darken(@color-background, 15%);
+  cursor: pointer;
+  display: inline-block;
+  padding: 0.25em 0.5em;
+  font-size: 1.2em;
+  text-align: center;
+  vertical-align: middle;
+}
+
+@import './lobby';
 @import './panel-league';

--- a/lib/ui/app.js
+++ b/lib/ui/app.js
@@ -1,0 +1,85 @@
+/* eslint-env browser */
+
+import { el, setChildren } from 'redom';
+
+import gameFactory from './game-factory';
+import Lobby from './lobby';
+
+import { listen } from './dispatch';
+
+
+export default class App {
+  constructor() {
+    this.socket = null;
+
+    this.el = el('', this.lobby = new Lobby());
+  }
+
+  onmount() {
+    listen(this);
+    this.installSocket();
+  }
+
+  onunmount() {
+    this.uninstallSocket();
+  }
+
+  installSocket() {
+    const socket = window.io();
+
+    this.socket = socket;
+
+    this.socket.on('client error', (data) => {
+      window.alert(`Client side error:\n${data.message}`);
+    });
+
+    this.socket.on('connected', (data) => {
+      if (!this.game) {
+        throw new Error('Connected to an game without requesting to join/create it.');
+      }
+      this.game.onEstablishConnection(Object.assign({ socket: this.socket }, data));
+    });
+
+    this.socket.on('clock', (data) => {
+      if (!this.game) {
+        throw new Error('Received game event without being joined in a game.');
+      }
+      this.game.onClock(data);
+    });
+
+    this.socket.on('game list', (data) => {
+      this.lobby.update(data.games);
+    });
+  }
+
+  uninstallSocket() {
+    if (this.socket) {
+      this.socket.close();
+      delete this.socket;
+    }
+  }
+
+  onRequestGameList() {
+    if (this.socket) {
+      this.socket.emit('game list');
+    }
+  }
+
+  onCreateNewGame({ mode }) {
+    if (this.socket) {
+      const game = gameFactory(mode, this.socket);
+
+      this.socket.emit('game create', { mode });
+      setChildren(this.el, [this.game = game]);
+    }
+  }
+
+  onJoinGame({ id, mode }) {
+    if (this.socket) {
+      const game = gameFactory(mode, this.socket);
+
+      this.socket.emit('game join', { id });
+      setChildren(this.el, [this.game = game]);
+    }
+  }
+}

--- a/lib/ui/game-factory.js
+++ b/lib/ui/game-factory.js
@@ -1,0 +1,17 @@
+import PanelLeagueDuelGame from './panel-league/game-duel';
+
+
+const gameMapping = {
+  'panel-league-duel': PanelLeagueDuelGame,
+};
+
+
+module.exports = function (gameModeName, socket) {
+  const gameModeClass = gameMapping[gameModeName];
+
+  if (!gameModeClass) {
+    throw new Error(`Unrecognized game mode: ${gameModeName}`);
+  }
+
+  return new gameModeClass(socket);
+};

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -2,12 +2,12 @@
 
 import { mount } from 'redom';
 
-import PanelLeagueGameDuel from './panel-league/game-duel';
+import App from './app';
 
 require('../../asset/css/style.less');
 
 
-const initialize = () => mount(document.body, new PanelLeagueGameDuel(window.io()));
+const initialize = () => mount(document.body, new App());
 
 if (document.readyState !== 'loading') {
   initialize();

--- a/lib/ui/lobby.js
+++ b/lib/ui/lobby.js
@@ -1,0 +1,86 @@
+import { el, list } from 'redom';
+
+import { dispatch } from './dispatch';
+
+
+class GameInfo {
+  constructor() {
+    this.el = el('tr',
+      this.gameModeDisplay = el('td'),
+      this.playerCountDisplay = el('td')
+    );
+
+    this.el.onclick = (ev) => {
+      ev.preventDefault();
+      this.el.classList.toggle('selected');
+    };
+
+    this.el.ondblclick = (ev) => {
+      ev.preventDefault();
+      if (this.id && this.isJoinable) {
+        dispatch(this, 'JoinGame', { id: this.id, mode: this.mode });
+      }
+    };
+  }
+
+  get isJoinable() {
+    return this.playerCount < this.maximumPlayerCount;
+  }
+
+  update({ id, mode, playerCount, maximumPlayerCount }) {
+    this.id = id;
+    this.mode = mode;
+    this.playerCount = playerCount;
+    this.maximumPlayerCount = maximumPlayerCount;
+
+    this.gameModeDisplay.innerText = `${this.mode}`;
+    this.playerCountDisplay.innerText = `${this.playerCount} / ${this.maximumPlayerCount}`;
+  }
+}
+
+
+export default class Lobby {
+  constructor(socket) {
+    this.socket = socket;
+
+    this.el = el('.lobby',
+      el('',
+        this.refreshButton = el('button', { type: 'button' }, 'Refresh'),
+        this.createGameButton = el('button', { type: 'button' }, 'Create new game'),
+      ),
+      el('table',
+        el('thead',
+          el('tr',
+            el('th', 'Game mode'),
+            el('th', 'Players')
+          )
+        ),
+        this.games = list('tbody', GameInfo, 'id')
+      )
+    );
+
+    this.refreshButton.onclick = (ev) => {
+      ev.preventDefault();
+      if (this.socket) {
+        this.socket.emit('game list');
+      }
+    };
+
+    this.createGameButton.onclick = (ev) => {
+      ev.preventDefault();
+      dispatch(this, 'CreateNewGame', { mode: 'panel-league-duel' });
+    };
+  }
+
+  onmount() {
+    dispatch(this, 'RequestGameList');
+  }
+
+  onremount() {
+    dispatch(this, 'RequestGameList');
+  }
+
+  update(games) {
+    this.games.update(games);
+  }
+}

--- a/lib/ui/panel-league/game-duel.js
+++ b/lib/ui/panel-league/game-duel.js
@@ -9,12 +9,11 @@ import { NetworkGameEngine } from '../../common/engine';
 
 
 export default class PanelLeagueGameDuel extends PanelLeagueGameBase {
-  constructor(socket) {
+  constructor() {
     super();
 
     this.el.classList.add('panel-league-duel');
 
-    this.socket = socket;
     this.playerGrid = null;
     this.opponentGrid = null;
   }
@@ -29,7 +28,6 @@ export default class PanelLeagueGameDuel extends PanelLeagueGameBase {
   onmount() {
     super.onmount();
 
-    this.installSocketListeners();
     setChildren(this.el, [el('h1', 'Waiting for an opponent to join...')]);
   }
 
@@ -37,70 +35,50 @@ export default class PanelLeagueGameDuel extends PanelLeagueGameBase {
     this.uninstallGameTimer();
   }
 
-  installSocketListeners() {
-    this.socket.on('client error', data => {
-      window.alert(`Client side error:\n${data.message}`);
+  onEstablishConnection({ socket, player, game, frameRate }) {
+    this.player = player;
+    this.engine = NetworkGameEngine.unserialize(game);
+    this.engine.installSocket(socket);
+    this.frameRate = frameRate;
+
+    this.playerGrid = new Grid({
+      width: this.engine.width,
+      height: this.engine.height,
+      player: this.player,
     });
-
-    this.socket.on('connected', data => {
-      this.player = data.player;
-      this.engine = NetworkGameEngine.unserialize(data.game);
-      this.engine.installSocket(this.socket);
-      this.frameRate = data.frameRate;
-
-      this.playerGrid = new Grid({
-        width: this.engine.width,
-        height: this.engine.height,
-        player: this.player,
-      });
-      this.opponentGrid = new Grid({
-        width: this.engine.width,
-        height: this.engine.height,
-        player: 1 - this.player,
-      });
-      setChildren(this.el, [this.playerGrid, this.opponentGrid]);
-      this.installGameTimer();
-      this.playerGrid.installEventListeners();
-
-      this.engine.on('chainMatchMade', effect => {
-        if (effect.player != null) {
-          // Match indices are sorted and we take the one closest to the top.
-          const chainingBlockIndex = effect.indices[0];
-
-          this.getPlayerGrid(effect.player).blocks[chainingBlockIndex].addTooltip(`${effect.chainNumber}`);
-        }
-      });
-
-      this.engine.on('addRow', effect => {
-        if (effect.player != null) {
-          --this.getPlayerGrid(effect.player).swapper.y;
-        }
-      }, false);
+    this.opponentGrid = new Grid({
+      width: this.engine.width,
+      height: this.engine.height,
+      player: 1 - this.player,
     });
+    setChildren(this.el, [this.playerGrid, this.opponentGrid]);
+    this.installGameTimer();
+    this.playerGrid.installEventListeners();
 
-    this.socket.on('clock', data => {
-      const serverTime = data.time;
+    this.engine.on('chainMatchMade', effect => {
+      if (effect.player != null) {
+        // Match indices are sorted and we take the one closest to the top.
+        const chainingBlockIndex = effect.indices[0];
 
-      if (!this.isRunning) {
-        return;
-      }
-      while (this.engine.time < serverTime) {
-        this.step();
-      }
-      this.waitTime = this.engine.time - serverTime;
-    });
-
-    this.socket.on('game list', data => {
-      const game = data.games.find(game => game.playerCount < game.maximumPlayerCount);
-
-      if (game) {
-        this.socket.emit('game join', { id: game.id });
-      } else {
-        this.socket.emit('game create', { mode: 'panel-league-duel' });
+        this.getPlayerGrid(effect.player).blocks[chainingBlockIndex].addTooltip(`${effect.chainNumber}`);
       }
     });
 
-    this.socket.emit('game list');
+    this.engine.on('addRow', effect => {
+      if (effect.player != null) {
+        --this.getPlayerGrid(effect.player).swapper.y;
+      }
+    }, false);
+  }
+
+  onClock({ time }) {
+    if (!this.isRunning) {
+      return;
+    }
+    while (this.engine.time < time) {
+      this.step();
+    }
+    this.waitTime = this.engine.time - time;
   }
 
   installGameTimer() {


### PR DESCRIPTION
Add very simple and crude lobby to the application which is displayed when the user isn't playing any game. It is capable of listing games currently running on the server, joining them and creating a new game. (Only Panel League duel supported at the moment.) However, joining to pretty much any game mode is already supported, as there exists an factory function for creating game user interfaces.