### PR TITLE
Disable Panel League Duel creation

### DIFF
--- a/lib/ui/lobby.js
+++ b/lib/ui/lobby.js
@@ -9,7 +9,7 @@ const gameModeVerboseNames = {
   'panel-league-sandbox': 'Panel League sandbox',
 };
 
-const creatableGameModes = ['puyo:duel', 'puyo:endless', 'panel-league-duel'];
+const creatableGameModes = ['puyo:duel', 'puyo:endless'];
 
 class GameInfo {
   constructor() {


### PR DESCRIPTION
The game mode is unfinished and should be hidden in production.

refs https://github.com/frostburn/panel-league/issues/102