### PR TITLE
Clear effects on Puyo game over

### DIFF
--- a/lib/common/puyo/stepper.js
+++ b/lib/common/puyo/stepper.js
@@ -219,6 +219,11 @@ class EndlessStepper extends BasicStepper {
     if (state.blocks.every(block => block !== basic.emptyPuyo)) {
       state.blocks.fill(basic.emptyPuyo);
       ++state.gameOvers;
+      // Replace effects with game overs.
+      effects.length = 0;
+      effects.push({
+        type: 'gameOver',
+      });
     }
     return effects;
   }
@@ -359,12 +364,13 @@ class DuelStepper extends BasicStepper {
       });
     });
 
-    this.handleGameOvers(state, events);
+    this.handleGameOvers(state, events, effects);
 
     return effects;
   }
 
-  handleGameOvers(state, events) {
+  handleGameOvers(state, events, effects) {
+    const gameOverEffects = [];
     let gameOver = false;
     let terminated = false;
     let terminationReason;
@@ -379,6 +385,10 @@ class DuelStepper extends BasicStepper {
           terminationReason = `Player ${childState.player} lost`;
           terminatedPlayer = childState.player;
         }
+        gameOverEffects.push({
+          type: 'gameOver',
+          player: childState.player,
+        });
       }
     });
     if (gameOver) {
@@ -393,8 +403,12 @@ class DuelStepper extends BasicStepper {
         childState.allClearBonus = false;
         childState.chainClearBonus = false;
         childState.dealIndex = 0;
+        childState.effects = [];
       });
       state.deals = state.deals.slice(-state.numDeals);
+      // Clear the rest of the effects and replace them with game overs.
+      effects.length = 0;
+      effects.push(...gameOverEffects);
     }
 
     if (terminated) {


### PR DESCRIPTION
Clear step effects so that empty puyos don't end up displaying falling or clearing visuals.

refs https://github.com/frostburn/panel-league/issues/166