### PR TITLE
Tweak the viewport for mobile

### DIFF
--- a/asset/css/lobby.less
+++ b/asset/css/lobby.less
@@ -4,7 +4,7 @@
   margin-left: auto;
   margin-right: auto;
   margin-top: 2em;
-  width: 50%;
+  width: 90%;
 
   table {
     margin-top: 2em;

--- a/asset/css/puyo.less
+++ b/asset/css/puyo.less
@@ -7,6 +7,7 @@
 }
 
 .game.puyo {
+  width: 100%;
   .endless {
     display: grid;
     grid-template-areas:

--- a/asset/css/variables.less
+++ b/asset/css/variables.less
@@ -38,7 +38,6 @@
 @symbol-block-x-circle: '\f057';
 @symbol-block-ban: '\f05e';
 
-@puyo-grid-height: 80vh;
-@puyo-block-size: @puyo-grid-height / 15;
+@puyo-block-size: 7.5vw;
 @puyo-display-size: @puyo-block-size;
 @puyo-small-size: @puyo-block-size * 0.6;

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
   <title>Panel League</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>


### PR DESCRIPTION
Tweak the viewport so that Puyo is playable on mobile in potrait orientation.
This makes the game unplayable in landscape mode but we'll fix that later.